### PR TITLE
AWS transfer script + $DRYAD_DB_HOST

### DIFF
--- a/aws-tools/psql_query.sh
+++ b/aws-tools/psql_query.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Query postgres in a way that allows easy processing of the results in a bash script
+psql --host=$DRYAD_DB_HOST \
+   --port=5432 \
+   --username=dryad_app  \
+   --dbname=dryad_repo \
+   -t \
+   --no-align \
+   --field-separator ' ' \
+   --quiet \
+   -c "$1"

--- a/fix_orcids_in_authorities.py
+++ b/fix_orcids_in_authorities.py
@@ -8,14 +8,12 @@ import re
 import os
 import sys
 import string
-from sql_utils import rows_from_query
+from sql_utils import rows_from_query, sql_query
 
 def update_authority(authority, metadata_value_id):
     new_authority = string.replace(authority, "will be generated::orcid::", "orcid:")
     sql = "update metadatavalue set authority = \'%s\' where metadata_value_id = %s" % (new_authority, metadata_value_id)
-    cmd = "psql -A -U dryad_app dryad_repo -c \"%s\"" % sql
-    print cmd
-    return os.popen(cmd)
+    return sql_query(sql)
         
 
 def main():

--- a/nsf_reporting.py
+++ b/nsf_reporting.py
@@ -10,13 +10,12 @@ import sys
 import shutil
 import hashlib
 from time import strptime, strftime
-from sql_utils import dict_from_query, var_from_query, rows_from_query
+from sql_utils import dict_from_query, var_from_query, rows_from_query, sql_query
 # import datetime
 
 def update_sponsor_id(name, item_id):
     sql = "update shoppingcart set sponsor_id = %s where journal='%s'" % (item_id, name)
-    cmd = "psql -U dryad_app dryad_repo -c \"%s\"" % sql
-    print os.popen(cmd).read()
+    print sql_query(sql).read()
 
 def get_field_id(name):
     parts = re.split('\.', name)

--- a/replace_largefile_bitstream.py
+++ b/replace_largefile_bitstream.py
@@ -8,7 +8,7 @@ import sys
 import shutil
 import hashlib
 import mimetypes
-from sql_utils import dict_from_query
+from sql_utils import dict_from_query, sql_query
 
 ASSETSTORE_PATH = '/opt/dryad-data/assetstore/'
 
@@ -120,8 +120,7 @@ def update_bitstream_table(bitstream_id, large_file):
         bitstream_id
     )
     print "Executing SQL: %s" % sql
-    cmd = "psql -U dryad_app dryad_repo -c \"%s\"" % sql
-    print os.popen(cmd).read()
+    print sql_query(sql).read()
 
 
 def main():

--- a/s3_calculate_md5_metadata.py
+++ b/s3_calculate_md5_metadata.py
@@ -35,10 +35,12 @@ def main():
                         hash.update(chunk)
                 md5 = hash.hexdigest()
                 os.remove(local_path)
-                cmd = '/usr/local/bin/aws s3 cp "s3://%s/%s" "s3://%s/%s" --metadata md5=%s' % (bucket, key, bucket, key, md5)
-
+                cmd = 'aws s3 cp "s3://%s/%s" "s3://%s/%s" --metadata md5=%s' % (bucket, key, bucket, key, md5)
                 os.popen(cmd)
                 print "  added md5 tag of %s" % (md5)
+            else:
+                cmd = 'aws s3 cp "s3://%s/%s" "s3://%s/%s" --metadata md5=%s' % (bucket, key, bucket, key, md5)
+                os.popen(cmd)
         else:
             print "  md5 tag is %s" % (metadata['Metadata']['md5'])
     sys.stdout.flush()            

--- a/s3_list_ftp_files.py
+++ b/s3_list_ftp_files.py
@@ -5,8 +5,6 @@ __author__ = 'daisie'
 import os
 import re
 
-TRANSFER_PATH = '/dryad-data/transfer-complete/'
-
 def main():
     cmd = 'aws s3 ls s3://dryad-ftp/ --recursive'
     results = list(os.popen(cmd))

--- a/s3_move_local_bitstreams.py
+++ b/s3_move_local_bitstreams.py
@@ -23,7 +23,7 @@ def validate_s3_file(bitstream):
     result = os.popen(cmd).read()
     if (result != ""):
         metadata = json.loads(result)
-        if ('md5' is in metadata['Metadata']):
+        if ('md5' in metadata['Metadata']):
             if (long(bitstream['size_bytes']) == long(metadata['ContentLength'])) and (bitstream['checksum'] == metadata['Metadata']['md5']):
                 return True
     return False

--- a/s3_move_local_bitstreams.py
+++ b/s3_move_local_bitstreams.py
@@ -23,8 +23,9 @@ def validate_s3_file(bitstream):
     result = os.popen(cmd).read()
     if (result != ""):
         metadata = json.loads(result)
-        if (long(bitstream['size_bytes']) == long(metadata['ContentLength'])) and (bitstream['checksum'] == metadata['Metadata']['md5']):
-            return True
+        if ('md5' is in metadata['Metadata']):
+            if (long(bitstream['size_bytes']) == long(metadata['ContentLength'])) and (bitstream['checksum'] == metadata['Metadata']['md5']):
+                return True
     return False
     
 def update_database(bitstream_id):

--- a/s3_move_local_bitstreams.py
+++ b/s3_move_local_bitstreams.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+# Move bitstreams from local assetstore to S3 bucket
+
+__author__ = 'daisie'
+
+import os
+import re
+import sys
+import json
+import hashlib
+from sql_utils import list_from_query, sql_query
+
+ASSETSTORE_BUCKET = os.environ['ASSETSTORE_BUCKET']
+ASSETSTORE_PATH = '/opt/dryad-data/assetstore/'
+
+def get_assetstore_path(internal_id):
+    parts = (internal_id[0:2],internal_id[2:4],internal_id[4:6])
+    return ASSETSTORE_PATH + '/'.join(parts) + '/' + internal_id
+
+def main():
+    print "Gathering bitstreams..."
+    bitstreams = list_from_query("select bitstream_id, internal_id, checksum, size_bytes from bitstream where deleted=false and store_number=0 order by bitstream_id ASC")
+    print "Processing %d local bitstreams" % (len(bitstreams))
+
+    for bitstream in bitstreams:
+        internal_id = bitstream['internal_id']
+        md5 = bitstream['checksum']
+        bitstream_id = bitstream['bitstream_id']        
+        size = bitstream['size_bytes']
+        print "Copying %s to s3..." % (internal_id)
+        cmd = 'aws s3 cp "%s" "s3://%s/%s" --metadata md5=%s --expected-size=%s' % (get_assetstore_path(internal_id), ASSETSTORE_BUCKET, internal_id, md5, size)
+        if (os.popen(cmd).close() is None):
+            print "Updating database..."
+            print sql_query("update bitstream set store_number=1 where bitstream_id=%s" % (bitstream_id)).read()
+        else:
+            print "AWS copy error, exiting"
+            exit(0)
+        
+        sys.stdout.flush()
+    
+    print "Done."
+        
+if __name__ == '__main__':
+    main()
+

--- a/s3_move_local_bitstreams.py
+++ b/s3_move_local_bitstreams.py
@@ -18,6 +18,19 @@ def get_assetstore_path(internal_id):
     parts = (internal_id[0:2],internal_id[2:4],internal_id[4:6])
     return ASSETSTORE_PATH + '/'.join(parts) + '/' + internal_id
 
+def validate_s3_file(bitstream):
+    cmd = 'aws s3api head-object --bucket %s --key "%s"' % (ASSETSTORE_BUCKET, bitstream['internal_id'])
+    result = os.popen(cmd).read()
+    if (result != ""):
+        metadata = json.loads(result)
+        if (long(bitstream['size_bytes']) == long(metadata['ContentLength'])) and (bitstream['checksum'] == metadata['Metadata']['md5']):
+            return True
+    return False
+    
+def update_database(bitstream_id):
+    print "Updating database..."
+    print sql_query("update bitstream set store_number=1 where bitstream_id=%s" % (bitstream_id)).read()
+
 def main():
     print "Gathering bitstreams..."
     bitstreams = list_from_query("select bitstream_id, internal_id, checksum, size_bytes from bitstream where deleted=false and store_number=0 order by bitstream_id ASC")
@@ -28,20 +41,23 @@ def main():
         md5 = bitstream['checksum']
         bitstream_id = bitstream['bitstream_id']        
         size = bitstream['size_bytes']
-        print "Copying %s to s3..." % (internal_id)
-        cmd = 'aws s3 cp "%s" "s3://%s/%s" --metadata md5=%s --expected-size=%s' % (get_assetstore_path(internal_id), ASSETSTORE_BUCKET, internal_id, md5, size)
-        if (os.popen(cmd).close() is None):
-            print "Verifying file size and md5..."
-            cmd = 'aws s3api head-object --bucket %s --key "%s"' % (ASSETSTORE_BUCKET, internal_id)
-            metadata = json.load(os.popen(cmd))
-            if (long(size) != long(metadata['ContentLength'])) and (md5 is not metadata['Metadata']['md5']):
-                print "S3 copy does not match local copy, skipping database update."
-            else:
-                print "Updating database..."
-                print sql_query("update bitstream set store_number=1 where bitstream_id=%s" % (bitstream_id)).read()
+        
+        print "Checking to see if %s exists at S3..." % (internal_id)
+        if (validate_s3_file(bitstream)):
+            print "File %s already exists at S3" % (internal_id)
+            update_database(bitstream_id)
         else:
-            print "AWS copy error, exiting"
-            exit(1)
+            print "Copying %s to s3..." % (internal_id)
+            cmd = 'aws s3 cp "%s" "s3://%s/%s" --metadata md5=%s --expected-size=%s' % (get_assetstore_path(internal_id), ASSETSTORE_BUCKET, internal_id, md5, size)
+            if (os.popen(cmd).close() is None):
+                print "Verifying file size and md5 of %s..." % (internal_id)
+                if validate_s3_file(bitstream):
+                    update_database(bitstream_id)
+                else:
+                    print "S3 copy does not match local copy, skipping database update."
+            else:
+                print "AWS copy error, exiting"
+                exit(1)
         
         sys.stdout.flush()
     

--- a/s3_replace_largefile_bitstream.py
+++ b/s3_replace_largefile_bitstream.py
@@ -106,7 +106,7 @@ def update_bitstream_table(bitstream_id, large_file):
         format_id = 1
     else:
         format_id = format_dict['bitstream_format_id'] # stays a string
-    sql = "UPDATE bitstream set size_bytes=%d, name='%s', source='%s' ,checksum='%s', bitstream_format_id=%s where bitstream_id = %d" % (
+    sql = "UPDATE bitstream set store_number=1, size_bytes=%d, name='%s', source='%s' ,checksum='%s', bitstream_format_id=%s where bitstream_id = %d" % (
         large_file.size,
         large_file.name,
         large_file.name,
@@ -134,6 +134,7 @@ def main():
     try:
         print "Checking existence of dummy file %s..." % (get_object_key(bitstream_id))
         dummyfile = bitstream_file(get_object_key(bitstream_id), ASSETSTORE_BUCKET)
+        print "Checking existence of large file %s..." % (largefile_key)
         largefile = bitstream_file(largefile_key, FTP_BUCKET)
     except BaseException as e:
         print "Unable to read file: %s" % e

--- a/s3_replace_largefile_bitstream.py
+++ b/s3_replace_largefile_bitstream.py
@@ -10,7 +10,7 @@ import re
 import os
 import sys
 import json
-from sql_utils import dict_from_query
+from sql_utils import dict_from_query, sql_query
 
 FTP_BUCKET = "dryad-ftp"
 ASSETSTORE_BUCKET = os.environ['ASSETSTORE_BUCKET']
@@ -115,8 +115,7 @@ def update_bitstream_table(bitstream_id, large_file):
         bitstream_id
     )
     print "Executing SQL: %s" % sql
-    cmd = "psql -U dryad_app dryad_repo -c \"%s\"" % sql
-    print os.popen(cmd).read()
+    print sql_query(sql).read()
 
 
 def main():

--- a/s3_replace_largefile_bitstream.py
+++ b/s3_replace_largefile_bitstream.py
@@ -38,7 +38,13 @@ class bitstream_file(object):
         self.size = metadata['ContentLength']
         self.name = os.path.basename(self.s3key)
         self.mimetype = metadata['ContentType']
-        self.md5 = metadata['Metadata']['md5']
+        if 'md5' in metadata['Metadata']:
+            self.md5 = metadata['Metadata']['md5']
+        else:
+            self.md5 = metadata['ETag']
+            if '-' in self.md5:
+                print "Can't find MD5"
+                exit(1)
     def __unicode__(self):
         return u'Name: %s, Size: %d, MD5: %s, Mime-Type: %s' % (self.name, self.size, self.md5, self.mimetype)
 
@@ -126,7 +132,7 @@ def main():
 
     largefile = None
     try:
-        print "Checking existence of dummy file..."
+        print "Checking existence of dummy file %s..." % (get_object_key(bitstream_id))
         dummyfile = bitstream_file(get_object_key(bitstream_id), ASSETSTORE_BUCKET)
         largefile = bitstream_file(largefile_key, FTP_BUCKET)
     except BaseException as e:

--- a/sql_utils.py
+++ b/sql_utils.py
@@ -7,9 +7,22 @@ __author__ = 'daisieh'
 import re
 import os
 
+global DRYAD_DB
+
+if 'DRYAD_DB_HOST' in os.environ:
+	DRYAD_DB = os.environ['DRYAD_DB_HOST']
+else:
+	DRYAD_DB = ""	
+
+def sql_query(sql):
+	global DRYAD_DB
+	host = ""
+	if DRYAD_DB is not "":
+		host = "--host " + DRYAD_DB
+	return os.popen("psql %s -A -U dryad_app dryad_repo -c \"%s\"" % (host, sql))
+
 def dict_from_query(sql):
-    cmd = "psql -A -U dryad_app dryad_repo -c \"%s\"" % sql
-    output = [line.strip().split('|') for line in os.popen(cmd).readlines()]
+    output = [line.strip().split('|') for line in sql_query(sql).readlines()]
     if len(output) <= 2: # the output should have at least 3 lines: header, body rows, number of rows
         return None
     else:
@@ -17,9 +30,7 @@ def dict_from_query(sql):
         return result
         
 def list_from_query(sql):
-    # Now execute it
-    cmd = "psql -A -U dryad_app dryad_repo -c \"%s\"" % sql
-    output = [line.strip().split('|') for line in os.popen(cmd).readlines()]
+    output = [line.strip().split('|') for line in sql_query(sql).readlines()]
     if len(output) == 1:
         return None
     else:
@@ -51,9 +62,7 @@ def list_values_for_key(key,dict_list):
     return result
 
 def rows_from_query(sql):
-    # Now execute it
-    cmd = "psql -A -U dryad_app dryad_repo -c \"%s\"" % sql
-    output = [line.strip().split('|') for line in os.popen(cmd).readlines()]
+    output = [line.strip().split('|') for line in sql_query(sql).readlines()]
     if len(output) <= 2: # the output should have at least 3 lines: header, body rows, number of rows
         return None
     else:
@@ -66,7 +75,6 @@ def var_from_query(sql, param):
     return None
 
 def execute_sql_query(sql):
-    cmd = "psql -A -U dryad_app dryad_repo -c \"%s\"" % sql
-    output = os.popen(cmd).readlines()
+    output = sql_query(sql).readlines()
     for line in output:
     	print line


### PR DESCRIPTION
Added a script to transfer all locally-stored bitstreams to the S3 bucket named at $ASSETSTORE_BUCKET.

In addition, I reworked the methods in sql_utils.py to use the pghost specified by $DRYAD_DB_HOST, if available. Otherwise, it skips that flag. I then updated all the scripts that call on a command-line psql invocation to use the generic sql_query method so that they’ll always use the correct pghost.
