### PR TITLE
backup_crontab script

### DIFF
--- a/backup_crontab.sh
+++ b/backup_crontab.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+INSTANCE_NAME=$1
+
+crontab -l | diff - /home/ubuntu/crontab.txt
+
+if [[ $? -ne 0 ]]; then
+	crontab -l > /home/ubuntu/crontab.txt
+	/home/ubuntu/.local/bin/aws s3 cp /home/ubuntu/crontab.txt s3://dryad-backup/crontabs/$INSTANCE_NAME.txt
+fi

--- a/backup_crontab.sh
+++ b/backup_crontab.sh
@@ -1,5 +1,8 @@
 #! /bin/bash
 
+# Loads a backed-up crontab for INSTANCE_NAME from dryad-backup/crontabs at S3. 
+# Takes a single argument, the instance name.
+
 INSTANCE_NAME=$1
 
 crontab -l | diff - /home/ubuntu/crontab.txt &>/dev/null

--- a/backup_crontab.sh
+++ b/backup_crontab.sh
@@ -2,7 +2,7 @@
 
 INSTANCE_NAME=$1
 
-crontab -l | diff - /home/ubuntu/crontab.txt
+crontab -l | diff - /home/ubuntu/crontab.txt &>/dev/null
 
 if [[ $? -ne 0 ]]; then
 	crontab -l > /home/ubuntu/crontab.txt


### PR DESCRIPTION
meant for vagrant: in the default crontab template, we should run this instead of the first crontab entry.