### PR TITLE
Update older scripts

### DIFF
--- a/doi_tool.py
+++ b/doi_tool.py
@@ -26,6 +26,11 @@ def main():
     parser.add_option("--password", dest="password", help="EZID password")
     (options, args) = parser.parse_args()
     opt_array = dict(doi=options.doi, is_blackout=options.is_blackout, action=options.action, username=options.username, password=options.password)
+    try:
+        s = subprocess.check_output(['which', 'xsltproc'])
+    except subprocess.CalledProcessError as e:
+        print "xsltproc is not installed. Please install using apt-get install xsltproc or similar."
+        return
     run_ezid(opt_array)
     
 def run_ezid(options):

--- a/doi_tool.py
+++ b/doi_tool.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import shlex
 import tempfile
+import urllib
 from optparse import OptionParser
 
 from ezid import process
@@ -61,11 +62,14 @@ def run_ezid(options):
     doi_path = 'http://datadryad.org/resource/%s/mets.xml' % (doi)
     target_url = 'http://datadryad.org/resource/%s' % (doi)
     
+    crosswalk_file = tempfile.NamedTemporaryFile(delete=False)
     if options['is_blackout'] is True:
-        cmd = 'xsltproc /opt/dryad/config/crosswalks/DIM2DATACITE-BLACKOUT.xsl %s' % doi_path
+        urllib.urlretrieve('https://raw.githubusercontent.com/datadryad/dryad-repo/dryad-master/dspace/config/crosswalks/DIM2DATACITE-BLACKOUT.xsl', crosswalk_file.name)
+        cmd = 'xsltproc %s %s' % (crosswalk_file.name, mets_file.name)
         target_url = 'http://datadryad.org/publicationBlackout'
     else:   
-        cmd = 'xsltproc /opt/dryad/config/crosswalks/DIM2DATACITE.xsl %s' % doi_path
+        urllib.urlretrieve('https://raw.githubusercontent.com/datadryad/dryad-repo/dryad-master/dspace/config/crosswalks/DIM2DATACITE.xsl', crosswalk_file.name)
+        cmd = 'xsltproc %s %s' % (crosswalk_file.name, mets_file.name)
     f = tempfile.NamedTemporaryFile(delete=False)
     subprocess.Popen(shlex.split(cmd), stdout=f).communicate()
 
@@ -78,6 +82,7 @@ def run_ezid(options):
 #     ['create', 'doi:10.5061/DRYAD.8157N', '_target', 'http://datadryad.org/resource/doi:10.5061/dryad.8157n', 'datacite', '@/Users/daisie/Desktop/test.xml']
     process(args)
     os.remove(f.name)
+    os.remove(crosswalk_file.name)
 
 if __name__ == '__main__':
     main()

--- a/doi_tool.py
+++ b/doi_tool.py
@@ -59,8 +59,10 @@ def run_ezid(options):
     
     # add target:
     args.append('_target')
-    doi_path = 'http://datadryad.org/resource/%s/mets.xml' % (doi)
-    target_url = 'http://datadryad.org/resource/%s' % (doi)
+    target_url = 'https://datadryad.org/resource/%s' % (doi)
+    
+    mets_file = tempfile.NamedTemporaryFile(delete=False)
+    urllib.urlretrieve('https://datadryad.org/resource/%s/mets.xml' % (doi), mets_file.name)
     
     crosswalk_file = tempfile.NamedTemporaryFile(delete=False)
     if options['is_blackout'] is True:
@@ -83,6 +85,7 @@ def run_ezid(options):
     process(args)
     os.remove(f.name)
     os.remove(crosswalk_file.name)
+    os.remove(mets_file.name)
 
 if __name__ == '__main__':
     main()

--- a/fix_tasklistitems.py
+++ b/fix_tasklistitems.py
@@ -8,28 +8,15 @@
 #
 # fix_tasklistitems.py doi:10.5061/dryad.xxxxx
 #
-# It connects to the Postgres database with parameters specified in dryad_credentials.py.
-# This script does not exist in the repo, you should create it:
-#
-# credentials = {
-#  'user': 'username',
-#  'password': 'password',
-#  'host': '127.0.0.1',
-#  'port': 6543,
-#  'database': 'database',
-#  }
-#
-# To use this with a remote server, create an SSH tunnel, e.g.:
-# ssh -L 6543:127.0.0.1:5432 username@host.com
+# It connects to the Postgres database with parameters specified in environment variables:
+# PGPASSWORD and DRYAD_DB_HOST should already be defined.
 
 from sqlalchemy import Table, MetaData, create_engine
 import sys, copy
 import os
-from dryad_credentials import credentials
 
 def get_engine():
-  connection_string = "postgresql://%s:%s@%s:%d/%s" % (credentials['user'], credentials['password'], credentials['host'], credentials['port'], credentials['database'])
-  print 'connecting to %s' % credentials['host']
+  connection_string = "postgresql://%s:%s@%s:%d/%s" % ('dryad_app', os.environ['PGPASSWORD'], os.environ['DRYAD_DB_HOST'], 5432, 'dryad_repo')
   engine = create_engine(connection_string)
   return engine
 


### PR DESCRIPTION
fix_tasklistitem.py was updated to use newer methods of obtaining db credentials

doi_tool.py now obtains the necessary crosswalks from github directly, as well as checks for the presence of the required program xsltproc. It also downloads the mets.xml file to a temp file for use by xsltproc.