### PR TITLE
Lowercase email

### DIFF
--- a/change_email.py
+++ b/change_email.py
@@ -23,7 +23,7 @@ if __name__ == '__main__':
         sys.exit()
     print "Current email address is: %s" % (user_dict['email'])
     new_address = raw_input('Enter the new email address: ')
-    execute_sql_query("update eperson set email = '%s' where eperson_id = %s;" % (new_address, user_id))
+    execute_sql_query("update eperson set email = '%s' where eperson_id = %s;" % (new_address.lower(), user_id))
     items = rows_from_query('select item_id from item where submitter_id = %s;' % (user_id))
     for item in items[1:len(items)-1]:
         statement = "bash /opt/dryad/bin/dspace update-discovery-index -i %s" % (item[0])

--- a/change_email.py
+++ b/change_email.py
@@ -22,8 +22,8 @@ if __name__ == '__main__':
         print "Did not find a matching eperson"
         sys.exit()
     print "Current email address is: %s" % (user_dict['email'])
-    new_address = raw_input('Enter the new email address: ')
-    execute_sql_query("update eperson set email = '%s' where eperson_id = %s;" % (new_address.lower(), user_id))
+    new_address = raw_input('Enter the new email address: ').lower().strip()
+    execute_sql_query("update eperson set email = '%s' where eperson_id = %s;" % (new_address, user_id))
     items = rows_from_query('select item_id from item where submitter_id = %s;' % (user_id))
     for item in items[1:len(items)-1]:
         statement = "bash /opt/dryad/bin/dspace update-discovery-index -i %s" % (item[0])

--- a/change_email.py
+++ b/change_email.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
     if is_user_id is not None:
         user_dict = dict_from_query("select * from eperson where eperson_id = %s;" % (user_spec))
     else:
-        user_dict = dict_from_query("select * from eperson where email = '%s';" % (user_spec))
+        user_dict = dict_from_query("select * from eperson where email = '%s';" % (user_spec.strip().lower()))
     if user_dict is not None:
         user_id = user_dict['eperson_id']
     else:

--- a/doi_tool.py
+++ b/doi_tool.py
@@ -84,6 +84,7 @@ def run_ezid(options):
         fh.write("No properly formatted DOI provided\n")
         return
     
+    data = {}
     # add target:
     if 'DRYAD_URL' in os.environ:
         DRYAD_URL = os.environ['DRYAD_URL']

--- a/doi_tool.py
+++ b/doi_tool.py
@@ -85,7 +85,7 @@ def run_ezid(options):
         return
     
     if action == "view":
-        print EZID_CLIENT.view(dc_doi)
+        fh.write(EZID_CLIENT.view(dc_doi))
         sys.exit()
         
     data = {}
@@ -114,9 +114,9 @@ def run_ezid(options):
     data['datacite'] = metadata.decode('utf-8')
     
     if action == "create":
-        print EZID_CLIENT.create(dc_doi, data)
+        fh.write(EZID_CLIENT.create(dc_doi, data))
     elif action == "update":
-        print EZID_CLIENT.update(dc_doi, data)
+        fh.write(EZID_CLIENT.update(dc_doi, data))
     
     os.remove(crosswalk_file.name)
     os.remove(mets_file.name)

--- a/doi_tool.py
+++ b/doi_tool.py
@@ -118,9 +118,6 @@ def run_ezid(options):
     elif action == "update":
         print EZID_CLIENT.update(dc_doi, data)
     
-#     ['create', 'doi:10.5061/DRYAD.8157N', '_target', 'http://datadryad.org/resource/doi:10.5061/dryad.8157n', 'datacite', '@/Users/daisie/Desktop/test.xml']
-    process(args, fh)
-    os.remove(f.name)
     os.remove(crosswalk_file.name)
     os.remove(mets_file.name)
 

--- a/doi_tool.py
+++ b/doi_tool.py
@@ -44,7 +44,6 @@ def run_ezid(options):
     global EZID_CLIENT, DOI_SERVER, DOI_USER, DOI_PASSWORD
     # options should have doi, is_blackout, action, username, password
     doi = options['doi']
-    f = None
     
     if 'pipe' in options:
         fh = options['pipe']

--- a/doi_tool.py
+++ b/doi_tool.py
@@ -84,6 +84,10 @@ def run_ezid(options):
         fh.write("No properly formatted DOI provided\n")
         return
     
+    if action == "view":
+        print EZID_CLIENT.view(dc_doi)
+        sys.exit()
+        
     data = {}
     # add target:
     if 'DRYAD_URL' in os.environ:

--- a/reindex-discovery.py
+++ b/reindex-discovery.py
@@ -38,6 +38,8 @@ def update_ezid(item_id, f):
     doi = dict_from_query("select text_value from metadatavalue where item_id = %s and metadata_field_id = %s;" % (item_id, doi_field_id))['text_value']
     if doi is not None:
         options = dict(doi=doi, is_blackout='False', action='update', username=_username, password=_password)
+        if f is not None:
+            options['pipe'] = f
         doi_tool.run_ezid(options)
     sys.stdout.flush()
 


### PR DESCRIPTION
I never noticed before, but apparently emails are only searched by the lowercased version, so we need to make sure that we only change emails to lowercased versions (and also stripping leading/trailing spaces while we’re at it).