### PR TITLE
Add option for skipping database

### DIFF
--- a/aws-tools/import_recent_dryad.sh
+++ b/aws-tools/import_recent_dryad.sh
@@ -1,9 +1,18 @@
 #! /bin/bash
 
+# Usage: import_recent_dryad.sh [skipdb]
+#
+# If the 'skipdb' parameter is present, the database is not updated
 
 echo "grabbing latest from aws..."
-/home/ubuntu/.local/bin/aws s3 cp s3://dryad-backup/databaseBackups/dryadDBlatest.sql $HOME/dryadDBlatest.sql 
-import_pg_dump.sh $HOME/dryadDBlatest.sql
 
+if [ "a$1" != "askipdb" ]
+then
+   echo "Database..."
+   /home/ubuntu/.local/bin/aws s3 cp s3://dryad-backup/databaseBackups/dryadDBlatest.sql $HOME/dryadDBlatest.sql 
+   import_pg_dump.sh $HOME/dryadDBlatest.sql
+fi
+
+echo "SOLR..."
 mkdir -p /opt/dryad/solr
 /home/ubuntu/.local/bin/aws s3 sync s3://dryad-backup/solrBackups/ /opt/dryad/solr --delete

--- a/aws-tools/import_recent_dryad.sh
+++ b/aws-tools/import_recent_dryad.sh
@@ -6,7 +6,7 @@
 
 echo "grabbing latest from aws..."
 
-if [ "a$1" != "askipdb" ]
+if [ "$1" != "skipdb" ]
 then
    echo "Database..."
    /home/ubuntu/.local/bin/aws s3 cp s3://dryad-backup/databaseBackups/dryadDBlatest.sql $HOME/dryadDBlatest.sql 

--- a/aws-tools/psql_query.sh
+++ b/aws-tools/psql_query.sh
@@ -7,6 +7,6 @@ psql --host=$DRYAD_DB_HOST \
    --dbname=dryad_repo \
    -t \
    --no-align \
-   --field-separator ' ' \
+   --field-separator $'\t'\
    --quiet \
    -c "$1"


### PR DESCRIPTION
On secundus, the database is a read-only replica of production. So we don't want to import new database content (attempting an import will result in an error). 

This change adds the optional argument "skipdb", which will cause the script to skip updates of the database, while still updating the SOLR index.

To test, run the script with and without the "skipdb" parameter.

(Also includes a change of field separator, which was made on secundus but never added to github)

