### PR TITLE
Add apache_heavy_hitters.sh

### DIFF
--- a/apache_heavy_hitters.sh
+++ b/apache_heavy_hitters.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo "Heaviest users of Apache today..."
+awk '{print $1}' /home/ubuntu/apache/log/datadryad.org-access.log | sort | uniq -c | sort -nr | head -10
+


### PR DESCRIPTION
Script to parse apache logs for IPs with heavy usage.