### PR TITLE
Add a quick-and-dirty report for submitter affiliations

### DIFF
--- a/affiliations-quick/README.txt
+++ b/affiliations-quick/README.txt
@@ -1,0 +1,19 @@
+Quick and dirty report of Dryad submissions by university.
+
+```
+The base report is a Postgres query to list submitter email addresses and counts of submissions:
+\copy (select email, count(item_id) from eperson, item where
+eperson.eperson_id = item.submitter_id and item.in_archive=true and
+item.owning_collection=2 group by eperson.eperson_id order by count
+desc;) to 'authorReport.csv' with CSV; 
+```
+
+Then the report is processed using the perl scripts in this directory
+to parse out the "university" portion of the email address and sum by
+university:
+
+```
+perl report.pl <authorReport.csv >authorReportDomains.csv
+sort authorReportDomains.csv >authorReportDomainsSort.csv
+perl report2.pl <authorReportDomainsSort.csv >reportByEmail.csv
+```

--- a/affiliations-quick/report.pl
+++ b/affiliations-quick/report.pl
@@ -1,0 +1,31 @@
+#!/usr/bin/perl
+
+# Assumes input (stdin) is a list of "email address, number of submissions"
+# Produces output as a list of "shortened domain name, number of submissions, email address"
+
+use strict;
+
+while(<>) {
+    my @x = split(',', $_);
+
+    my $fulladdress = $x[0];
+    chomp($x[1]);
+    my $count= $x[1];
+    
+    my @domainarr = split(/\@/,$fulladdress);
+    my $fulldomain = $domainarr[1];
+    
+    my @domainparts = split('\.', $fulldomain);
+
+    # If the domain has "ac" in the second-to-last spot, or is in the uk or au TLD, 
+    # we need 3 parts to make a full institution name. Otherwise we only need 2 parts
+    my $shortdomain;
+    if( ($domainparts[-2] eq "edu") || ($domainparts[-2] eq "ac") || ($domainparts[-1] eq "uk") || ($domainparts[-1] eq "au")) {
+	$shortdomain = "$domainparts[-3]\.$domainparts[-2]\.$domainparts[-1]";
+    } else {
+	$shortdomain = "$domainparts[-2]\.$domainparts[-1]";
+    }
+    
+    print "$shortdomain, $count, $fulladdress\n";
+}
+

--- a/affiliations-quick/report2.pl
+++ b/affiliations-quick/report2.pl
@@ -1,0 +1,28 @@
+#!/usr/bin/perl
+
+# Assumes input is a list of "shortened domain name, number of submissions, possibly other stuff...."
+# Assumes input is sorted, so all instances of a shortened domain name are on adjacent lines.
+# Produces output as "shortened domain name, total submissions from that domain"
+
+
+use strict;
+
+my $previousdomain = "";
+my $currenttotal = 0;
+
+while(<>) {
+    my @x = split(',', $_);
+
+    my $shortdomain = $x[0];
+    my $count= $x[1];
+    
+    if( $shortdomain eq $previousdomain ) {
+	$currenttotal = $currenttotal + $count;
+    } else {
+	print "$previousdomain, $currenttotal\n";
+	$currenttotal = $count;
+	$previousdomain = $shortdomain;
+    }
+}
+
+print "$previousdomain, $currenttotal\n";


### PR DESCRIPTION
This report was produced to generate a quick estimate of the number of submissions from each "university". 

See output, now with annotations, in the Google Spreadsheet titled "Report -- All Submitters by Domain"