### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/doi-checks/test-dryad-file-dois.sh
+++ b/doi-checks/test-dryad-file-dois.sh
@@ -40,11 +40,11 @@
 
 while read doi ; do
     pkgdoi=`echo "$doi" | sed -e 's/\/[0-9][.0-9]*$//'`
-    resp=`curl -L -H "Accept: text/x-bibliography" -s -w "%{http_code}" -o /dev/null http://dx.doi.org/"$doi"`
+    resp=`curl -L -H "Accept: text/x-bibliography" -s -w "%{http_code}" -o /dev/null https://doi.org/"$doi"`
     if [ "$resp" -lt 400 ] ; then
         echo -e "$doi\tresolves"
     else 
-        resp=`curl -L -H "Accept: text/x-bibliography" -s -w "%{http_code}" -o /dev/null http://dx.doi.org/"$pkgdoi"`
+        resp=`curl -L -H "Accept: text/x-bibliography" -s -w "%{http_code}" -o /dev/null https://doi.org/"$pkgdoi"`
         if [ "$resp" -lt 400 ] ; then
             echo -e "$doi\tfails"
         else

--- a/doi-checks/update-dois.sh
+++ b/doi-checks/update-dois.sh
@@ -8,7 +8,7 @@
 DOI_TOOL_LOCATION="/home/ubuntu/dryad-utils/doi_tool.py"
 
 while read doi ; do
-    resp=`curl -L -H "Accept: text/x-bibliography" -s -w "%{http_code}" -o /dev/null http://dx.doi.org/"$doi"`
+    resp=`curl -L -H "Accept: text/x-bibliography" -s -w "%{http_code}" -o /dev/null https://doi.org/"$doi"`
     if [ "$resp" -lt 400 ] ; then
         echo -e "$doi\tresolves, updating"
 	resp=`$DOI_TOOL_LOCATION --doi=$doi --action=update`

--- a/make_markup.py
+++ b/make_markup.py
@@ -25,7 +25,7 @@ def render_itemsummary(journal_name, journal_url, cover_image):
                     <xsl:choose>\n\
                         <xsl:when test=\"contains($article-doi,'doi:')\">\n\
                             <xsl:value-of\n\
-                                    select=\"concat('http://dx.doi.org/', substring-after($article-doi, 'doi:'))\"/>\n\
+                                    select=\"concat('https://doi.org/', substring-after($article-doi, 'doi:'))\"/>\n\
                         </xsl:when>\n\
                         <xsl:otherwise>\n\
                             <xsl:value-of\n\

--- a/nsf_reporting.py
+++ b/nsf_reporting.py
@@ -34,10 +34,10 @@ def main():
     startdate = strptime(sys.argv[1], "%Y-%m-%d")
     enddate = strptime(sys.argv[2], "%Y-%m-%d")
     prov_field = get_field_id('dc.description.provenance')
-    items = rows_from_query ("select distinct nsf.item_id, substring(prov.text_value, 'Made available in DSpace on (\d+-\d+-\d+)T.+') from metadatavalue as nsf, metadatavalue as prov where nsf.authority='https://doi.org/10.13039/100000001' and nsf.item_id=prov.item_id and prov.metadata_field_id=%s and prov.text_value like 'Made available in DSpace%%' order by substring" % prov_field)
+    items = rows_from_query ("select distinct nsf.item_id, substring(prov.text_value, 'Made available in DSpace on (\d+-\d+-\d+)T.+') from metadatavalue as nsf, metadatavalue as prov where nsf.authority='http://dx.doi.org/10.13039/100000001' or nsf.authority='https://doi.org/10.13039/100000001' and nsf.item_id=prov.item_id and prov.metadata_field_id=%s and prov.text_value like 'Made available in DSpace%%' order by substring" % prov_field)
     labels = dict(zip(items[0], range(0,len(items[0]))))
 
-    nsf_sponsor_id = var_from_query("select parent_id from conceptmetadatavalue where text_value = 'https://doi.org/10.13039/100000001'",'parent_id')
+    nsf_sponsor_id = var_from_query("select parent_id from conceptmetadatavalue where text_value = 'http://dx.doi.org/10.13039/100000001' or text_value = 'https://doi.org/10.13039/100000001'",'parent_id')
    
     print "item\tarchive date\tdoi\tgrant provided\tis valid?\tNSF Sponsored?\ttitle\tauthors"
     for item in items[1:-1]:

--- a/nsf_reporting.py
+++ b/nsf_reporting.py
@@ -34,10 +34,10 @@ def main():
     startdate = strptime(sys.argv[1], "%Y-%m-%d")
     enddate = strptime(sys.argv[2], "%Y-%m-%d")
     prov_field = get_field_id('dc.description.provenance')
-    items = rows_from_query ("select distinct nsf.item_id, substring(prov.text_value, 'Made available in DSpace on (\d+-\d+-\d+)T.+') from metadatavalue as nsf, metadatavalue as prov where nsf.authority='http://dx.doi.org/10.13039/100000001' and nsf.item_id=prov.item_id and prov.metadata_field_id=%s and prov.text_value like 'Made available in DSpace%%' order by substring" % prov_field)
+    items = rows_from_query ("select distinct nsf.item_id, substring(prov.text_value, 'Made available in DSpace on (\d+-\d+-\d+)T.+') from metadatavalue as nsf, metadatavalue as prov where nsf.authority='https://doi.org/10.13039/100000001' and nsf.item_id=prov.item_id and prov.metadata_field_id=%s and prov.text_value like 'Made available in DSpace%%' order by substring" % prov_field)
     labels = dict(zip(items[0], range(0,len(items[0]))))
 
-    nsf_sponsor_id = var_from_query("select parent_id from conceptmetadatavalue where text_value = 'http://dx.doi.org/10.13039/100000001'",'parent_id')
+    nsf_sponsor_id = var_from_query("select parent_id from conceptmetadatavalue where text_value = 'https://doi.org/10.13039/100000001'",'parent_id')
    
     print "item\tarchive date\tdoi\tgrant provided\tis valid?\tNSF Sponsored?\ttitle\tauthors"
     for item in items[1:-1]:


### PR DESCRIPTION
Same as https://github.com/datadryad/dryad-linkout-tool/pull/13 ;-) I'm not entirely sure about the [suggested change to `nsf_reporting.py`](https://github.com/datadryad/dryad-utils/pull/63/files#diff-92198705f89fec519764e426d1344e42), because I have little work experience with SQL querying. Will that change match both existing (old DOI URL) and future (new DOI URL) data?